### PR TITLE
Fix: Correct DMN naming inconsistency

### DIFF
--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -6,7 +6,7 @@ This document outlines the high-level architecture of the NDML system. It descri
 
 The NDML system is built around a set of core components that provide the fundamental functionalities for neuromorphic distributed memory.
 
-### Enhanced Distributed Memory Node (DMN)
+### GPUAcceleratedDMN (DMN)
 Individual memory storage units with biological plasticity. These nodes are responsible for storing and managing memory traces. They implement mechanisms for memory encoding, retrieval, and local updates based on biological principles.
 
 ### Multi-Timescale Dynamics Engine
@@ -38,7 +38,7 @@ These components facilitate the interaction of the core NDML system with externa
 The MemoryGateway coordinates distributed memory operations across multiple MemoryClusters. It acts as a central access point for storing and retrieving memories from the distributed network of DMNs. It handles routing of requests and aggregation of results.
 
 ### MemoryCluster
-A MemoryCluster is a group of Enhanced Distributed Memory Nodes (DMNs). Clustering DMNs allows for better organization, scalability, and fault tolerance. The MemoryGateway interacts with MemoryClusters to manage the distributed memory.
+A MemoryCluster is a group of GPUAcceleratedDMN (DMNs). Clustering DMNs allows for better organization, scalability, and fault tolerance. The MemoryGateway interacts with MemoryClusters to manage the distributed memory.
 
 ### NDMLIntegratedLLM
 This component provides a seamless integration of the NDML system with Large Language Models (LLMs). It allows an LLM to leverage the neuromorphic memory capabilities of NDML for tasks such as:
@@ -56,7 +56,7 @@ The typical flow of information and interaction between these components is as f
 2.  The **NDMLIntegratedLLM** processes requests, which may involve storing new information or retrieving existing memories.
 3.  For memory operations, the **NDMLIntegratedLLM** communicates with the **MemoryGateway**.
 4.  The **MemoryGateway** routes requests to the appropriate **MemoryCluster(s)**.
-5.  Within a **MemoryCluster**, the request is handled by one or more **Enhanced Distributed Memory Nodes (DMNs)**.
+5.  Within a **MemoryCluster**, the request is handled by one or more **GPUAcceleratedDMN (DMNs)**.
 6.  The **DMNs** utilize the **Multi-Timescale Dynamics Engine** and **BTSP Update Mechanism** to process memory updates and lifecycle events, managed by the **Memory Lifecycle Manager**.
 7.  Retrieved memories are passed back up the chain to the **NDMLIntegratedLLM**, which then integrates them into the LLM's processing.
 

--- a/docs/requirements.md
+++ b/docs/requirements.md
@@ -87,7 +87,7 @@ The installation process is automated through the `install_ndml.sh` script, whic
 The NDML system consists of several key components:
 
 ### Core Components
-- **EnhancedDistributedMemoryNode (DMN)**: The central memory node that manages memory traces
+- **GPUAcceleratedDMN (DMN)**: The central memory node that manages memory traces
 - **MemoryTrace**: Represents individual memory items with metadata
 - **BTSPUpdateMechanism**: Biologically-inspired plasticity mechanism
 - **MemoryLifecycleManager**: Manages memory lifecycle (creation, consolidation, eviction)

--- a/integration/memory_gateway.py
+++ b/integration/memory_gateway.py
@@ -9,7 +9,7 @@ import logging
 import time
 from collections import defaultdict
 
-from core.dmn import EnhancedDistributedMemoryNode
+from core.dmn import GPUAcceleratedDMN
 
 logger = logging.getLogger(__name__)
 
@@ -522,7 +522,7 @@ class MemoryCluster:
         # Initialize nodes
         self.nodes = []
         for i in range(num_nodes):
-            node = EnhancedDistributedMemoryNode(
+            node = GPUAcceleratedDMN(
                 node_id=f"{cluster_id}_node_{i}",
                 dimension=dimension,
                 capacity=node_capacity,
@@ -801,12 +801,12 @@ class ClusterRouter(nn.Module):
 class NodeSelector:
     """Selects appropriate nodes within a cluster for queries and updates"""
 
-    def __init__(self, nodes: List[EnhancedDistributedMemoryNode], config: Dict[str, Any]):
+    def __init__(self, nodes: List[GPUAcceleratedDMN], config: Dict[str, Any]):
         self.nodes = nodes
         self.config = config
         self.selection_history = defaultdict(int)
 
-    async def select_nodes_for_query(self, query: torch.Tensor, context: Dict[str, Any]) -> List[EnhancedDistributedMemoryNode]:
+    async def select_nodes_for_query(self, query: torch.Tensor, context: Dict[str, Any]) -> List[GPUAcceleratedDMN]:
         """Select nodes for query retrieval."""
         
         # For retrieval, query ALL nodes to ensure we don't miss memories
@@ -824,7 +824,7 @@ class NodeSelector:
         return selected_nodes
 
     async def select_node_for_update(self, content: torch.Tensor,
-                                     context: Dict[str, Any]) -> EnhancedDistributedMemoryNode:
+                                     context: Dict[str, Any]) -> GPUAcceleratedDMN:
         """Select single node for memory update"""
 
         # For updates, we want to select the best single node

--- a/main.py
+++ b/main.py
@@ -67,7 +67,7 @@ def import_with_fallback():
         sys.path.append(os.path.dirname(os.path.abspath(__file__)))
 
         # Import existing modules
-        from core.dmn import EnhancedDistributedMemoryNode                    # ← needs "core."
+        from core.dmn import GPUAcceleratedDMN                    # ← needs "core."
         from core.memory_trace import MemoryTrace                             # ← needs "core."
         from core.btsp import BTSPUpdateMechanism                            # ← needs "core."
         from core.dynamics import MultiTimescaleDynamicsEngine               # ← needs "core."
@@ -75,7 +75,7 @@ def import_with_fallback():
         from integration.memory_gateway import MemoryGateway                 # ← needs "integration."
         from integration.fusion_network import MemoryFusionNetwork
 
-        components['dmn'] = EnhancedDistributedMemoryNode
+        components['dmn'] = GPUAcceleratedDMN
         components['memory_trace'] = MemoryTrace
         components['btsp'] = BTSPUpdateMechanism
         components['dynamics'] = MultiTimescaleDynamicsEngine


### PR DESCRIPTION
Replaced all instances of the incorrect class name 'EnhancedDistributedMemoryNode' with the correct class name 'GPUAcceleratedDMN'.

This change affects:
- Imports and instantiation in 'integration/memory_gateway.py'
- Imports and component registration in 'main.py'
- Mentions in 'docs/requirements.md'
- Mentions in 'docs/architecture.md'

The class 'GPUAcceleratedDMN' is the correctly implemented version in 'core/dmn.py'. This commit resolves potential ImportError and aligns the codebase and documentation.

## Summary by Sourcery

Rename all instances of the outdated EnhancedDistributedMemoryNode to GPUAcceleratedDMN to resolve import errors and unify code and documentation.

Bug Fixes:
- Replace imports and type hints for EnhancedDistributedMemoryNode with GPUAcceleratedDMN in memory_gateway.py and main.py
- Update component registration in main.py to use GPUAcceleratedDMN

Documentation:
- Correct mentions of EnhancedDistributedMemoryNode to GPUAcceleratedDMN in architecture.md
- Update requirements.md to list GPUAcceleratedDMN as the core DMN component