### PR TITLE
Fix: Resolve attribute and initialization errors

### DIFF
--- a/core/dmn.py
+++ b/core/dmn.py
@@ -231,7 +231,7 @@ class GPUAcceleratedDMN(IntegratedMemoryNode):
                     update_decision = await self.btsp.should_update_async(
                         content=content, # Pass original content
                         context=context,
-                        existing_traces=list(self.memory_traces.values()) if isinstance(self.memory_traces, dict) else self.memory_traces, # Pass the list of current traces
+                        existing_traces=self.memory_traces, # Pass the list of current traces
                         user_feedback=user_feedback
                     )
 


### PR DESCRIPTION
This commit addresses several issues:

1.  In `core/dmn.py`:
    *   Simplified the `existing_traces` argument passed to `should_update_async`
        in `GPUAcceleratedDMN.add_memory_trace_async` to correctly use
        `self.memory_traces` (which is a list).

2.  In `core/memory_trace.py` (manual changes by you):
    *   Removed duplicate definitions of `get_temporal_priority` and `to_dict` methods.
    *   Added `from core.lifecycle import MemoryLifecycleState`.
    *   Added the `state: MemoryLifecycleState = MemoryLifecycleState.ACTIVE`
        attribute to the `MemoryTrace` dataclass.
    *   Updated `to_dict` and `from_dict` to handle the serialization and
        deserialization of the new `state` field.

These changes resolve potential AttributeErrors and KeyErrors, and ensure consistency in the codebase.

## Summary by Sourcery

Fix attribute and initialization errors by correcting the existing_traces argument in GPUAcceleratedDMN.add_memory_trace_async and enhancing the MemoryTrace dataclass with a lifecycle state and updated serialization

Bug Fixes:
- Pass the correct list to should_update_async by using self.memory_traces in GPUAcceleratedDMN.add_memory_trace_async
- Remove duplicate get_temporal_priority and to_dict definitions in MemoryTrace to prevent method conflicts

Enhancements:
- Add a state field of type MemoryLifecycleState to the MemoryTrace dataclass
- Import MemoryLifecycleState and update to_dict/from_dict to handle serialization of the new state field