### PR TITLE
Improve MemoryGateway modularity and timing

### DIFF
--- a/__init__.py
+++ b/__init__.py
@@ -14,6 +14,10 @@ __description__ = "Neuromorphic Distributed Memory Layer for AI Systems"
 import logging
 import warnings
 from typing import Dict, Any, Optional
+import sys as _sys
+
+# Alias lowercase package name for safe imports
+_sys.modules.setdefault('ndml', _sys.modules[__name__])
 
 # Configure default logging
 logging.getLogger(__name__).addHandler(logging.NullHandler())

--- a/consensus/interface.py
+++ b/consensus/interface.py
@@ -1,0 +1,20 @@
+"""Consensus interface for NDML."""
+from __future__ import annotations
+
+import torch
+from abc import ABC, abstractmethod
+from typing import Dict, Any
+
+
+class ConsensusInterface(ABC):
+    """Abstract base class for consensus implementations."""
+
+    @abstractmethod
+    async def propose_memory_update(
+        self, trace_id: str, content_vector: torch.Tensor, metadata: Dict[str, Any]
+    ) -> bool:
+        """Propose a memory update to peers and return True on success."""
+
+    @abstractmethod
+    def get_stats(self) -> Dict[str, Any]:
+        """Return implementation specific statistics."""

--- a/core/__init__.py
+++ b/core/__init__.py
@@ -10,14 +10,22 @@ Contains the fundamental building blocks of the NDML system:
 - Memory lifecycle management
 """
 
-from .dmn import EnhancedDistributedMemoryNode
+try:
+    from .dmn import EnhancedDistributedMemoryNode
+except ImportError:  # Fallback if class is missing
+    EnhancedDistributedMemoryNode = None  # type: ignore
+
 from .memory_trace import MemoryTrace, TemporalMetadata, ConsolidationState
 from .dynamics import MultiTimescaleDynamicsEngine, TemporalState, TemporalEvent
 from .btsp import BTSPUpdateMechanism, BTSPUpdateDecision
 from .lifecycle import MemoryLifecycleManager, MemoryLifecycleState, LifecycleConfig
 
-__all__ = [
-    'EnhancedDistributedMemoryNode',
+if EnhancedDistributedMemoryNode is not None:
+    __all__ = ['EnhancedDistributedMemoryNode']
+else:
+    __all__ = []
+
+__all__ += [
     'MemoryTrace',
     'TemporalMetadata',
     'ConsolidationState',
@@ -30,3 +38,4 @@ __all__ = [
     'MemoryLifecycleState',
     'LifecycleConfig',
 ]
+

--- a/ndml/__init__.py
+++ b/ndml/__init__.py
@@ -1,0 +1,17 @@
+"""Compat package forwarding imports from repository root."""
+from importlib.util import spec_from_file_location, module_from_spec
+from pathlib import Path
+import sys
+
+_root = Path(__file__).resolve().parent.parent / "__init__.py"
+_parent = _root.parent
+if str(_parent) not in sys.path:
+    sys.path.insert(0, str(_parent))
+_spec = spec_from_file_location("ndml_root", _root, submodule_search_locations=[str(_root.parent)])
+_module = module_from_spec(_spec)
+sys.modules["ndml_root"] = _module
+_spec.loader.exec_module(_module)  # type: ignore
+
+for _name, _val in _module.__dict__.items():
+    if not _name.startswith("_"):
+        globals()[_name] = _val

--- a/ndml/consensus/__init__.py
+++ b/ndml/consensus/__init__.py
@@ -1,0 +1,11 @@
+from importlib import import_module
+from pathlib import Path
+import sys
+
+_parent = Path(__file__).resolve().parent.parent
+if str(_parent) not in sys.path:
+    sys.path.insert(0, str(_parent))
+_module = import_module('consensus')
+for _n, _v in list(_module.__dict__.items()):
+    if not _n.startswith('_'):
+        globals()[_n] = _v

--- a/ndml/core/__init__.py
+++ b/ndml/core/__init__.py
@@ -1,0 +1,11 @@
+from importlib import import_module
+from pathlib import Path
+import sys
+
+_parent = Path(__file__).resolve().parent.parent
+if str(_parent) not in sys.path:
+    sys.path.insert(0, str(_parent))
+_module = import_module('core')
+for _n, _v in list(_module.__dict__.items()):
+    if not _n.startswith('_'):
+        globals()[_n] = _v

--- a/ndml/integration/__init__.py
+++ b/ndml/integration/__init__.py
@@ -1,0 +1,11 @@
+from importlib import import_module
+from pathlib import Path
+import sys
+
+_parent = Path(__file__).resolve().parent.parent
+if str(_parent) not in sys.path:
+    sys.path.insert(0, str(_parent))
+_module = import_module('integration')
+for _n, _v in list(_module.__dict__.items()):
+    if not _n.startswith('_'):
+        globals()[_n] = _v

--- a/tests/consensus_stub.py
+++ b/tests/consensus_stub.py
@@ -1,0 +1,14 @@
+"""Test-only consensus stub implementing ConsensusInterface."""
+from typing import Dict, Any
+import torch
+from ndml.consensus.interface import ConsensusInterface
+
+
+class ConsensusStub(ConsensusInterface):
+    async def propose_memory_update(
+        self, trace_id: str, content_vector: torch.Tensor, metadata: Dict[str, Any]
+    ) -> bool:
+        return True
+
+    def get_stats(self) -> Dict[str, Any]:
+        return {"stub_consensus": True}


### PR DESCRIPTION
## Summary
- add consensus interface and testing stub
- switch MemoryGateway to use package-safe imports
- introduce pluggable routing strategies
- use `time.perf_counter` for load balancer timing
- expose repo as `ndml` package for safe imports

## Testing
- `pytest -q` *(fails: ModuleNotFoundError for `ndml`)*

------
https://chatgpt.com/codex/tasks/task_e_6852427afc24833282fa60ac9ad92425

## Summary by Sourcery

Improve MemoryGateway modularity and timing by introducing a consensus interface and pluggable routing strategies, exposing code via an ndml package, and switching timing calls to perf_counter.

New Features:
- Add ConsensusInterface abstraction with NeuromorphicConsensusLayer integration in MemoryGateway
- Introduce BaseRouterStrategy with RoundRobin and Weighted router implementations and enable strategy selection in ClusterRouter
- Expose repository code as an ‘ndml’ compatibility package for package-safe imports

Bug Fixes:
- Add fallback import for EnhancedDistributedMemoryNode in core to prevent ImportError

Enhancements:
- Use time.perf_counter instead of time.time for load balancer and NodeSelector timing
- Persist router strategy state in checkpoints and refactor routing logic to leverage strategy objects

Tests:
- Add test-only ConsensusStub implementing ConsensusInterface